### PR TITLE
Prepare release: build/ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.babelrc
+.circleci/
+.DS_Store
+.eslintrc
+.gitignore
+node_modules/
+src/
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "scripts": {
     "build": "babel src --out-dir lib",
-    "preversion": "yarn test",
+    "preversion": "yarn test && yarn build",
     "release:patch": "npm version patch && npm publish && git push --follow-tags",
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:major": "npm version major && npm publish && git push --follow-tags",


### PR DESCRIPTION
Add build command to `preversion` hook, and ignore development related files when publishing to NPM