### PR TITLE
Fix:`rn-list-clip-subviews`

### DIFF
--- a/src/rules/rn-list-clip-subviews.js
+++ b/src/rules/rn-list-clip-subviews.js
@@ -17,7 +17,7 @@ const isList = node => {
 };
 
 const getAttributes = node => {
-  return node.parent.attributes;
+  return node.parent.attributes.filter(attr => attr.type === 'JSXAttribute');
 };
 
 const findPreviousAttribute = attributes => {


### PR DESCRIPTION
Ensure `rn-list-clip-subviews` rule does not break with spread attributes

Relates to #14