### PR TITLE
Rule: error-object

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
     "node": true
   },
   "rules": {
+    "instawork/error-object": 0,
     "global-require": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-instawork",
   "version": "0.4.0",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "description": "ESLint plugin with opinionated rules used at Instawork",
   "keywords": [
     "eslint",

--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -50,6 +50,7 @@ const errorRules = {
   ],
   'instawork/component-methods-use-arrows': 'error',
   'instawork/deprecate-bound': 'error',
+  'instawork/error-object': 'error',
   'instawork/exact-object-types': 'error',
   'instawork/flow-annotate': 'error',
   'instawork/import-components': 'error',

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const rules = {
   'deprecate-components': require('./rules/deprecate-components'),
   'deprecate-imports': require('./rules/deprecate-imports'),
   'deprecate-stateless': require('./rules/deprecate-stateless'),
+  'error-object': require('./rules/error-object'),
   'exact-object-types': require('./rules/exact-object-types'),
   'flow-annotate': require('./rules/flow-annotate'),
   'import-components': require('./rules/import-components'),

--- a/src/rules/error-object.js
+++ b/src/rules/error-object.js
@@ -1,0 +1,37 @@
+// @flow
+
+const util = require('./util');
+
+const description = 'Should only use errors extending IWBaseError class';
+
+const meta = {
+  docs: {
+    description,
+  },
+};
+
+const create = context => ({
+  ClassDeclaration: node => {
+    const className = node.id.name;
+    const superclassName = util.getSuperclassName(node);
+    if (superclassName && /^Error$/.test(superclassName)) {
+      context.report(node, `'${className}' should extend IWBaseError instead of Error`);
+    }
+    if (superclassName && /^IWBaseError$/.test(superclassName)) {
+      const [, prefix, baseName, suffix] = className.match(/^(IW)?(.+?)(Error)?$/);
+      if (!prefix || !suffix) {
+        context.report(node, `'${className}' should be named 'IW${baseName}Error'`);
+      }
+    }
+  },
+  'NewExpression > Identifier': node => {
+    if (node.name === 'Error') {
+      context.report({
+        loc: node.loc,
+        message: `Should not directly instanciate object from 'Error' class, instead instanciate object from class extending 'IWBaseError'`,
+      });
+    }
+  },
+});
+
+module.exports = { create, meta };

--- a/src/rules/error-object.test.js
+++ b/src/rules/error-object.test.js
@@ -1,0 +1,40 @@
+// @flow
+
+const { RuleTester } = require('eslint');
+const rule = require('./error-object');
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+
+ruleTester.run('error-object', rule, {
+  invalid: [
+    {
+      code: 'class MyError extends Error {}',
+      errors: [{ message: /^'MyError' should extend IWBaseError instead of Error$/ }],
+    },
+    {
+      code: 'class MyClass extends IWBaseError {}',
+      errors: [{ message: /^'MyClass' should be named 'IWMyClassError'$/ }],
+    },
+    {
+      code: 'class MyClassError extends IWBaseError {}',
+      errors: [{ message: /^'MyClassError' should be named 'IWMyClassError'$/ }],
+    },
+    {
+      code: 'class IWMyClass extends IWBaseError {}',
+      errors: [{ message: /^'IWMyClass' should be named 'IWMyClassError'$/ }],
+    },
+    {
+      code: 'const foo = new Error()',
+      errors: [
+        {
+          message: /^Should not directly instanciate object from 'Error' class, instead instanciate object from class extending 'IWBaseError'$/,
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: 'class IWMyError extends IWBaseError {}',
+    },
+  ],
+});

--- a/src/rules/pure-components.js
+++ b/src/rules/pure-components.js
@@ -1,5 +1,7 @@
 // @flow
 
+const util = require('./util');
+
 const NAME_REGEX = /^Component$/i;
 
 const meta = {
@@ -8,25 +10,9 @@ const meta = {
   },
 };
 
-const getSuperclassName = classExpressionNode => {
-  const { superClass } = classExpressionNode;
-  if (!superClass) {
-    return null;
-  }
-
-  if (superClass.type === 'MemberExpression') {
-    return superClass.property.name;
-  }
-  if (superClass.type === 'Identifier') {
-    return superClass.name;
-  }
-
-  throw new Error(`Unexpected superClass type: ${superClass.type}`);
-};
-
 const create = context => ({
   ClassDeclaration: node => {
-    const superclassName = getSuperclassName(node);
+    const superclassName = util.getSuperclassName(node);
 
     if (superclassName && NAME_REGEX.test(superclassName)) {
       const className = node.id.name;

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -143,3 +143,19 @@ module.exports.isStoryDeclarationNode = node =>
 
 /** Given a story declaration node, returns the story name */
 module.exports.getStoryNameForStoryDeclarationNode = node => node.arguments[0].value;
+
+module.exports.getSuperclassName = classExpressionNode => {
+  const { superClass } = classExpressionNode;
+  if (!superClass) {
+    return null;
+  }
+
+  if (superClass.type === 'MemberExpression') {
+    return superClass.property.name;
+  }
+  if (superClass.type === 'Identifier') {
+    return superClass.name;
+  }
+
+  throw new Error(`Unexpected superClass type: ${superClass.type}`);
+};


### PR DESCRIPTION
Add new rule that validates the following:
- `Error` class should not be instantiated - instead a class that extend `IWBaseError` should be instantiated
- Error classes extending `IWBaseError` should have `Error` suffix
- Error classes should not directly extend `Error` - instead classes should extend `IWBaseError`

TAD: https://instawork.atlassian.net/wiki/spaces/EN/pages/941720541/O3KR4+-+Deliver+actionable+error+and+crash+reporting+tools#Technical-approach-on-improving-how-errors-are-thrown
Relates to https://app.asana.com/0/1154961818095721/1156042455185111/f