### PR TITLE
Errors: Enforce `name` instance property

### DIFF
--- a/src/rules/error-object.js
+++ b/src/rules/error-object.js
@@ -19,8 +19,19 @@ const create = context => ({
     }
     if (superclassName && /^IWBaseError$/.test(superclassName)) {
       const [, prefix, baseName, suffix] = className.match(/^(IW)?(.+?)(Error)?$/);
+      const expectedName = `IW${baseName}Error`;
       if (!prefix || !suffix) {
-        context.report(node, `'${className}' should be named 'IW${baseName}Error'`);
+        context.report(node, `'${className}' should be named '${expectedName}'`);
+      } else {
+        const namePropertyNode = node.body.body.find(
+          n => n.type === 'ClassProperty' && n.key.name === 'name',
+        );
+        if (!namePropertyNode || namePropertyNode.value.value !== className) {
+          context.report(
+            node,
+            `'${className}' should have an instance property 'name' set to '${expectedName}'`,
+          );
+        }
       }
     }
   },

--- a/src/rules/error-object.test.js
+++ b/src/rules/error-object.test.js
@@ -3,7 +3,7 @@
 const { RuleTester } = require('eslint');
 const rule = require('./error-object');
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+const ruleTester = new RuleTester({ parser: 'babel-eslint', parserOptions: { ecmaVersion: 2015 } });
 
 ruleTester.run('error-object', rule, {
   invalid: [
@@ -31,10 +31,18 @@ ruleTester.run('error-object', rule, {
         },
       ],
     },
+    {
+      code: 'class IWMyError extends IWBaseError {}',
+      errors: [
+        { message: /^'IWMyError' should have an instance property 'name' set to 'IWMyError'$/ },
+      ],
+    },
   ],
   valid: [
     {
-      code: 'class IWMyError extends IWBaseError {}',
+      code: `class IWMyError extends IWBaseError {
+        name = 'IWMyError';
+      }`,
     },
   ],
 });


### PR DESCRIPTION
Extend existing rules around error classes, to enforce definition of `name` instance property to the same value as the class name.

Relates to https://app.asana.com/0/1154961818095721/1156042455185111/f