### PR TITLE
Configure some rules as warning instead of error to ease update

### DIFF
--- a/src/config/recommended.js
+++ b/src/config/recommended.js
@@ -106,8 +106,18 @@ const warningRules = {
   'instawork/stories-components': 'warn',
   'instawork/stories-navbars': 'warn',
   'instawork/stories-screens': 'warn',
+  'max-classes-per-file': 'warn',
+  'prefer-object-spread': 'warn',
   'react/destructuring-assignment': ['warn', 'never'],
+  'react/forbid-prop-types': 'warn',
+  'react/jsx-fragments': 'warn',
+  'react/jsx-pascal-case': 'warn',
+  'react/jsx-props-no-spreading': 'warn',
   'react/jsx-sort-props': 'warn',
+  'react/no-deprecated': 'warn',
+  'react/prop-types': 'warn',
+  'react/state-in-constructor': 'warn',
+  'react/static-property-placement': 'warn',
   'sort-keys': 'warn',
 };
 


### PR DESCRIPTION
All new added rules are reflected as tasks to update in https://app.asana.com/0/426551029573976/1112529141606707/f