### PR TITLE
feat(okr-micro-fe-dx): Implemented a new rule `instawork/import-common` to restrict cross-app imports

### DIFF
--- a/src/config/common-config.js
+++ b/src/config/common-config.js
@@ -100,6 +100,7 @@ const errorRules = {
 const warningRules = {
   'instawork/deprecate-components': 'warn',
   'instawork/deprecate-stateless': 'warn',
+  'instawork/import-common': 'warn',
   'instawork/import-modules': 'warn',
   'instawork/import-services': 'warn',
   'instawork/pure-components': 'warn',

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const rules = {
   'exact-object-types': require('./rules/exact-object-types'),
   'flow-annotate': require('./rules/flow-annotate'),
   'helpers-utils-tests': require('./rules/helpers-utils-tests'),
+  'import-common': require('./rules/import-common'),
   'import-components': require('./rules/import-components'),
   'import-modules': require('./rules/import-modules'),
   'import-navbar': require('./rules/import-navbar'),

--- a/src/rules/import-common.js
+++ b/src/rules/import-common.js
@@ -3,12 +3,6 @@
 const path = require('path');
 
 module.exports = {
-  meta: {
-    type: 'suggestion',
-    docs: {
-      description: 'Enforce allowed imports from specific folders',
-    },
-  },
   create(context) {
     return {
       ImportDeclaration(node) {
@@ -31,10 +25,16 @@ module.exports = {
         }
 
         context.report({
-          node,
           message: `Import from '${node.source.value}' is not allowed`,
+          node,
         });
       },
     };
+  },
+  meta: {
+    docs: {
+      description: 'Enforce allowed imports from specific folders',
+    },
+    type: 'suggestion',
   },
 };

--- a/src/rules/import-common.js
+++ b/src/rules/import-common.js
@@ -1,0 +1,29 @@
+// @flow
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Enforce allowed imports from specific folders',
+    },
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+
+        // Define your not allowed prefix here
+        const notAllowedPrefix = ['microFE/'];
+
+        const isNotAllowed = notAllowedPrefix.some((prefix) => importPath.startsWith(prefix));
+
+        if (isNotAllowed) {
+          context.report({
+            node,
+            message: `Import from '${importPath}' is not allowed`,
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
### Description
Implemented a new rule `instawork/import-common` to restrict cross-app imports.

### How to use:

Add the following in the `.eslintrc` file in `overrides > rules`

```
module.exports = {
  ...,
  plugins: ['instawork'],
  overrides: [
    ...,
    {
      files: ['**/*.{ts,tsx}'],
      extends: 'plugin:instawork/recommended-web-ts',
      plugins: ['instawork'],
      rules: {
        ...,
        'instawork/import-common': [
          'error',
          {
            appsDirectory: 'web_frontend',
            appsDirectoryShorthandPrefix: 'microFE',
            allowed: ['common'],
          },
        ],
        ...
    }
  ]
};
```

### Example
<img width="1217" alt="image" src="https://github.com/Instawork/eslint-plugin-instawork/assets/8015195/7492db88-5776-41b3-883f-252d166adc01">
