### PR TITLE
Fix: updated regex to find store paths

### DIFF
--- a/src/rules/store-tests.js
+++ b/src/rules/store-tests.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const PATH_REGEX = /\/(store|store-*)\/([^/]+?)\/(index).(js|ts)$/i;
+const PATH_REGEX = /\/(store|store-*)\/(([^/]+?)\/)?(index).(js|ts)$/i;
 const EXPECTED_SUFFIX_REGEX = /.*\.(test|spec)\.(js|ts)$/i;
 
 const meta = {


### PR DESCRIPTION
### Summary
Fixed regex to find store to also match `index` files directly in the `store` or the `store-*` folders

### Screenshot

<img width="1336" alt="Screenshot 2024-01-08 at 6 07 09 PM" src="https://github.com/Instawork/eslint-plugin-instawork/assets/2883006/fa4a04b3-b17f-4a75-91ee-8204422b770c">
