### PR TITLE
Change post-install to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release:minor": "yarn version --minor",
     "release:major": "yarn version --major",
     "test": "eslint src --max-warnings 0 && jest src",
-    "postinstall": "patch-package"
+    "prepare": "patch-package"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "7.6.0",


### PR DESCRIPTION
Changes post-install to prepare, so that it only fires in dev mode (and not when being installed as a dependency).